### PR TITLE
chore: add 47 as a supported shell version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
   "description": "The good old original app menu. For GNOME Shell 45+.\n\n Code mostly copied from GNOME Shell code itself. For a customizable app menu, please consider 'Window title is back' extension.",
   "name": "App menu is back",
   "shell-version": [
-    "46"
+    "46",
+    "47"
   ],
   "url": "https://github.com/fthx/appmenu-is-back",
   "uuid": "appmenu-is-back@fthx",


### PR DESCRIPTION
The extension seems to work fine on the 47 alpha.