### PR TITLE
Gnome 49 Support + Spacing Fix

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -244,11 +244,8 @@ export default class AppMenuIsBackExtension {
     }
 
     enable() {
-        if (!Main.sessionMode.panel.left.includes('appMenu')) {
-            this._app_menu = new AppMenuButton();
-            Main.panel.addToStatusArea('appmenu-indicator', this._app_menu, -1, 'left');
-        }
-
+        this._app_menu = new AppMenuButton();
+        Main.panel.addToStatusArea('appmenu-indicator', this._app_menu, -1, 'left');
         this._shiftPlacesMenu();
     }
 

--- a/extension.js
+++ b/extension.js
@@ -2,11 +2,231 @@
 //    GNOME Shell extension
 //    @fthx 2025
 
-
 import GLib from 'gi://GLib';
+import Atk from 'gi://Atk';
+import Clutter from 'gi://Clutter';
+import GObject from 'gi://GObject';
+import Shell from 'gi://Shell';
+import St from 'gi://St';
 
+import * as Animation from 'resource:///org/gnome/shell/ui/animation.js';
+import {AppMenu} from 'resource:///org/gnome/shell/ui/appMenu.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as Overview from 'resource:///org/gnome/shell/ui/overview.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui//popupMenu.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 
+const PANEL_ICON_SIZE = 16;
+const APP_MENU_ICON_MARGIN = 0;
+
+/**
+ * AppMenuButton:
+ *
+ * This class manages the "application menu" component.  It tracks the
+ * currently focused application.  However, when an app is launched,
+ * this menu also handles startup notification for it.  So when we
+ * have an active startup notification, we switch modes to display that.
+ */
+const AppMenuButton = GObject.registerClass({
+    Signals: {'changed': {}},
+}, class AppMenuButton extends PanelMenu.Button {
+    _init() {
+        super._init(0.0, null, true);
+
+        this.accessible_role = Atk.Role.MENU;
+
+        this._startingApps = [];
+
+        this._menuManager = Main.panel.menuManager;
+        this._targetApp = null;
+
+        let bin = new St.Bin({name: 'appMenu'});
+        this.add_child(bin);
+
+        this.bind_property('reactive', this, 'can-focus', 0);
+        this.reactive = false;
+
+        this._container = new St.BoxLayout({style_class: 'panel-status-menu-box'});
+        bin.set_child(this._container);
+
+        let textureCache = St.TextureCache.get_default();
+        textureCache.connect('icon-theme-changed',
+            this._onIconThemeChanged.bind(this));
+
+        let iconEffect = new Clutter.DesaturateEffect();
+        this._iconBox = new St.Bin({
+            style_class: 'app-menu-icon',
+            y_align: Clutter.ActorAlign.CENTER,
+        });
+        this._iconBox.add_effect(iconEffect);
+        this._container.add_child(this._iconBox);
+
+        this._iconBox.connect('style-changed', () => {
+            let themeNode = this._iconBox.get_theme_node();
+            iconEffect.enabled = themeNode.get_icon_style() === St.IconStyle.SYMBOLIC;
+        });
+
+        this._label = new St.Label({
+            y_expand: true,
+            y_align: Clutter.ActorAlign.CENTER,
+        });
+        this._container.add_child(this._label);
+
+        this._visible = !Main.overview.visible;
+        if (!this._visible)
+            this.hide();
+        Main.overview.connectObject(
+            'hiding', this._sync.bind(this),
+            'showing', this._sync.bind(this), this);
+
+        this._spinner = new Animation.Spinner(PANEL_ICON_SIZE, {
+            animate: true,
+            hideOnStop: true,
+        });
+        this._container.add_child(this._spinner);
+
+        let menu = new AppMenu(this);
+        this.setMenu(menu);
+        this._menuManager.addMenu(menu);
+
+        Shell.WindowTracker.get_default().connectObject('notify::focus-app',
+            this._focusAppChanged.bind(this), this);
+        Shell.AppSystem.get_default().connectObject('app-state-changed',
+            this._onAppStateChanged.bind(this), this);
+        global.window_manager.connectObject('switch-workspace',
+            this._sync.bind(this), this);
+
+        this._sync();
+    }
+
+    fadeIn() {
+        if (this._visible)
+            return;
+
+        this._visible = true;
+        this.reactive = true;
+        this.remove_all_transitions();
+        this.ease({
+            opacity: 255,
+            duration: Overview.ANIMATION_TIME,
+            mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+        });
+    }
+
+    fadeOut() {
+        if (!this._visible)
+            return;
+
+        this._visible = false;
+        this.reactive = false;
+        this.remove_all_transitions();
+        this.ease({
+            opacity: 0,
+            mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+            duration: Overview.ANIMATION_TIME,
+        });
+    }
+
+    _syncIcon(app) {
+        const icon = app.create_icon_texture(PANEL_ICON_SIZE - APP_MENU_ICON_MARGIN);
+        this._iconBox.set_child(icon);
+    }
+
+    _onIconThemeChanged() {
+        if (this._iconBox.child == null)
+            return;
+
+        if (this._targetApp)
+            this._syncIcon(this._targetApp);
+    }
+
+    stopAnimation() {
+        this._spinner.stop();
+    }
+
+    startAnimation() {
+        this._spinner.play();
+    }
+
+    _onAppStateChanged(appSys, app) {
+        let state = app.state;
+        if (state !== Shell.AppState.STARTING)
+            this._startingApps = this._startingApps.filter(a => a !== app);
+        else if (state === Shell.AppState.STARTING)
+            this._startingApps.push(app);
+        // For now just resync on all running state changes; this is mainly to handle
+        // cases where the focused window's application changes without the focus
+        // changing.  An example case is how we map OpenOffice.org based on the window
+        // title which is a dynamic property.
+        this._sync();
+    }
+
+    _focusAppChanged() {
+        let tracker = Shell.WindowTracker.get_default();
+        let focusedApp = tracker.focus_app;
+        if (!focusedApp) {
+            // If the app has just lost focus to the panel, pretend
+            // nothing happened; otherwise you can't keynav to the
+            // app menu.
+            if (global.stage.key_focus != null)
+                return;
+        }
+        this._sync();
+    }
+
+    _findTargetApp() {
+        let workspaceManager = global.workspace_manager;
+        let workspace = workspaceManager.get_active_workspace();
+        let tracker = Shell.WindowTracker.get_default();
+        let focusedApp = tracker.focus_app;
+        if (focusedApp && focusedApp.is_on_workspace(workspace))
+            return focusedApp;
+
+        for (let i = 0; i < this._startingApps.length; i++) {
+            if (this._startingApps[i].is_on_workspace(workspace))
+                return this._startingApps[i];
+        }
+
+        return null;
+    }
+
+    _sync() {
+        let targetApp = this._findTargetApp();
+
+        if (this._targetApp !== targetApp) {
+            this._targetApp?.disconnectObject(this);
+
+            this._targetApp = targetApp;
+
+            if (this._targetApp) {
+                this._targetApp.connectObject('notify::busy', this._sync.bind(this), this);
+                this._label.set_text(this._targetApp.get_name());
+                this.set_accessible_name(this._targetApp.get_name());
+
+                this._syncIcon(this._targetApp);
+            }
+        }
+
+        let visible = this._targetApp != null && !Main.overview.visibleTarget;
+        if (visible)
+            this.fadeIn();
+        else
+            this.fadeOut();
+
+        let isBusy = this._targetApp != null &&
+                      (this._targetApp.get_state() === Shell.AppState.STARTING ||
+                       this._targetApp.get_busy());
+        if (isBusy)
+            this.startAnimation();
+        else
+            this.stopAnimation();
+
+        this.reactive = visible && !isBusy;
+
+        this.menu.setApp(this._targetApp);
+        this.emit('changed');
+    }
+});
 
 export default class AppMenuIsBackExtension {
     _shiftPlacesMenu() {
@@ -25,23 +245,18 @@ export default class AppMenuIsBackExtension {
 
     enable() {
         if (!Main.sessionMode.panel.left.includes('appMenu')) {
-            Main.sessionMode.panel.left.push('appMenu');
-            Main.panel._updatePanel();
-
-            Main.panel.statusArea.appMenu._container.remove_child(Main.panel.statusArea.appMenu._spinner);
+            this._app_menu = new AppMenuButton();
+            Main.panel.addToStatusArea('appmenu-indicator', this._app_menu, -1, 'left');
         }
 
         this._shiftPlacesMenu();
     }
 
     disable() {
-        if (Main.sessionMode.panel.left.includes('appMenu')) {
-            Main.sessionMode.panel.left.pop();
-            Main.panel._updatePanel();
-
-            Main.panel.statusArea.appMenu._container.add_child(Main.panel.statusArea.appMenu._spinner);
-            Main.panel.statusArea.appMenu?.destroy();
-        }
+        Main.panel.menuManager.removeMenu(this._app_menu.menu);
+        this._app_menu.destroy();
+        this._app_menu.menu = null;
+        delete this._app_menu;
 
         this._shiftPlacesMenu();
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "The good old original app menu. Uses native GNOME Shell button.\n\n For a customizable app menu, please consider 'Window title is back' extension.",
   "name": "App menu is back",
-  "shell-version": ["46", "47", "48"],
+  "shell-version": ["46", "47", "48", "49"],
   "url": "https://github.com/fthx/appmenu-is-back",
   "uuid": "appmenu-is-back@fthx",
   "version": 999

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,0 +1,3 @@
+.app-menu-icon {
+    margin-right: 8px;
+}


### PR DESCRIPTION
The first commit combines the logic from https://github.com/fthx/appmenu-is-back/blob/c251ff36d226dac679eb745638e3df236d3e1a20/extension.js and the Gnome 48 version of panel.js to provide support for Gnome 49.

The second commit adds some space between the text and icon, changing:

<img width="248" height="55" alt="Screenshot From 2025-10-06 22-22-00" src="https://github.com/user-attachments/assets/4d1cd514-1e4b-49ce-ba88-aa1881d3767c" />

to

<img width="248" height="55" alt="Screenshot From 2025-10-06 22-22-13" src="https://github.com/user-attachments/assets/eb007ade-d6cd-41e4-a024-5ccc66be16a5" />

If you'd prefer I open a new PR with just the fix for Gnome 49, let me know and I'd be happy to do that.