### PR TITLE
UI: Add spacing between app menu icon and label

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -44,6 +44,7 @@ const AppMenuButton = GObject.registerClass({
         this._iconBox = new St.Bin({
             style_class: 'app-menu-icon',
             y_align: Clutter.ActorAlign.CENTER,
+            style: 'margin-right: 4px;',
         });
         this._iconBox.add_effect(iconEffect);
         this._container.add_child(this._iconBox);


### PR DESCRIPTION
### What was the problem?

The icon and the text label in the app menu were too close together. This made the menu look cramped and a little hard to read.

### How does this change fix it?

I added a `margin-right` to the icon's container. This creates a small, consistent gap between the icon and the label, which makes the UI look cleaner and more balanced.

### Screenshots

**Before:**
<img width="288" height="65" alt="image" src="https://github.com/user-attachments/assets/04115ae7-a06b-4a09-b48e-e6ff77130939" />


**After:**
<img width="310" height="52" alt="image" src="https://github.com/user-attachments/assets/a1bc6221-ea53-4c99-a1a9-370756611f34" />
