### PR TITLE
add gs 50 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,8 @@
   "description": "The good old original app menu. Uses native GNOME Shell button.\n\n For a customizable app menu, please consider 'Window title is back' extension.",
   "name": "App menu is back",
   "shell-version": [
-    "49"
+    "49",
+    "50"
   ],
   "url": "https://github.com/fthx/appmenu-is-back",
   "uuid": "appmenu-is-back@fthx",


### PR DESCRIPTION
Add GNOME Shell 50 to the supported shell versions.

I checked the GNOME Shell 50 porting notes and upstream Shell APIs used by this extension; no code changes are needed, so this PR only updates `metadata.json`.