### PR TITLE
Compatibility with GNOME 50

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,8 @@
   "description": "The good old original app menu. Uses native GNOME Shell button.\n\n For a customizable app menu, please consider 'Window title is back' extension.",
   "name": "App menu is back",
   "shell-version": [
-    "49"
+    "49",
+    "50"
   ],
   "url": "https://github.com/fthx/appmenu-is-back",
   "uuid": "appmenu-is-back@fthx",


### PR DESCRIPTION
GNOME 50 is out, and the extension appears to work fine.

Just added GNOME 50 to the supported versions.