### PR TITLE
Support GNOME Shell 50

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -81,6 +81,11 @@ const AppMenuButton = GObject.registerClass({
 
         this._visible = true;
         this.reactive = true;
+        // _init() may have called hide() (when the extension is enabled while
+        // the overview is visible, e.g. during the login startup animation).
+        // Without show() here the actor stays hidden forever and only its
+        // opacity gets animated, so the button never comes back.
+        this.show();
         this.remove_all_transitions();
         this.ease({
             opacity: 255,

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,8 @@
   "description": "The good old original app menu. Uses native GNOME Shell button.\n\n For a customizable app menu, please consider 'Window title is back' extension.",
   "name": "App menu is back",
   "shell-version": [
-    "49"
+    "49",
+    "50"
   ],
   "url": "https://github.com/fthx/appmenu-is-back",
   "uuid": "appmenu-is-back@fthx",


### PR DESCRIPTION
 Adds GNOME Shell 50 support.

  ### `metadata.json`
  Added `"50"` to `shell-version`.

  ### `extension.js` — `fadeIn()` never un-hides the button

  `_init()` calls `this.hide()` when the extension is enabled while the
  overview is visible, but `fadeIn()` only animates `opacity`. Since the
  opacity was never lowered in that path, the tween runs 255 → 255 while the
  actor stays `visible = false`, so the button never appears again — silently,
  with nothing in the log.

  On GNOME 49 this rarely triggered. On GNOME 50 the startup animation goes
  through the overview, so the extension is enabled with `Main.overview.visible`
  true on every login and the app menu is simply missing until the extension is
  toggled off and on.

  Fixed by calling `this.show()` in `fadeIn()` before the tween.

  Tested on GNOME Shell 50.4 (Fedora 44)